### PR TITLE
Add a README to examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Each file in this folder:
+- Is a demo of some quantum computing well known feature.
+- It has documentation in the code (pending).
+- Is a standalone file with a `main()` function that will be built into a standalone binary.
+- When an example runs it will send useful output to the user.
+
+## Build
+
+Examples will be built by default when `cargo build` runs. They can also be built with:
+
+```
+cargo build --examples
+```
+
+or individually:
+
+```
+cargo build --example dense_coding
+```
+
+## Run
+
+```
+cargo run --example dense_coding
+```


### PR DESCRIPTION
As there is a link to the examples in [main page](https://github.com/Renmusxd/RustQIP/blob/master/README.md) i think it will be useful for the user to get some information on how to build, use and what to expect when they visit the [examples folder](https://github.com/Renmusxd/RustQIP/tree/master/examples)